### PR TITLE
Feature/fix issue 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wide/modulus",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Robust Web Component interface",
   "license": "MIT",
   "author": "Aymeric Assier (https://github.com/myeti)",

--- a/src/component.js
+++ b/src/component.js
@@ -107,9 +107,10 @@ export default class Component {
    * Listen to global event bus
    * @param {String} event
    * @param {Function} fn
+   * @param {Object} [params={}]
    */
-  on(event, fn) {
-    const ref = emitter.on(event, fn)
+  on(event, fn, params = {}) {
+    const ref = emitter.on(event, fn, params)
     this.__meta.listeners.push({ event, ref: ref.ref, opts: ref.opts, keyRef: fn })
   }
 


### PR DESCRIPTION
### Issue #2 fixed.  

Third optional parameter added on `on()` method

```js
  /**
   * Listen to global event bus
   * @param {String} event
   * @param {Function} fn
   * @param {Object} [params={}]
   */
  on(event, fn, params = {}) {
    const ref = emitter.on(event, fn, params)
    this.__meta.listeners.push({ event, ref: ref.ref, opts: ref.opts, keyRef: fn })
  }
```