### PR TITLE
Feature/fix issue 9

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ modulus.component('modal', class extends Component {
    *
    * @params {HTMLElement} el
    * @params {Event} e
-   * @params {Object} [data]
+   * @params {Object|null} [data]
    */
   open({ el, e, data }) {
     // el: <button ...>

--- a/readme.md
+++ b/readme.md
@@ -103,22 +103,44 @@ Use the `[data-call]` helper with a formatted value `name#id.method`:
 
 will internally trigger:
 ```js
-modulus.seek('modal', '#register').open()
+modulus.seek('modal', '#register').open({ el, e, data })
 ```
-
-#### Parameters
-Use the `[data-call.params]` to pass some predefined values:
 
 | Value | Description |
-|---|---|---|---|
-| `$event` | `Event` object of the event listener method callback |
-| `$el` | Element object binded to the event |
+|---|---|
+| `el` | HTMLElement object binded to the event |
+| `e` | `Event` object of the event listener method callback |
+| `data` | Optional parameters defined in `[data-call.params]` |
+
+#### Parameters
+Use the `[data-call.params]` to pass custom values:
 
 ```html
-<button data-call="modal#register.open" data-call.params="$event">do something</button>
+<button data-call="modal#register.open" data-call.params='[{ "myAttr": "myValue" }]'>do something</button>
 ```
 
+> ⚠️ Note: `data-call.params` is waiting a JSON format only
 
+Exmple with the previous HTML code:
+```js
+modulus.component('modal', class extends Component {
+  run() {
+    // ...
+  }
+
+  /**
+   * Open modal and do some stuff
+   *
+   * @params {HTMLElement} el
+   * @params {Event} e
+   * @params {Object} [data]
+   */
+  open({ el, e, data }) {
+    // el: <button ...>
+    // e: Event{ ... }
+    // data: { ... } | null
+  }
+```
 
 ## Component class
 

--- a/src/directives.js
+++ b/src/directives.js
@@ -1,13 +1,16 @@
 import observe from '@wide/dom-observer'
 import { seek } from './index'
+import { parseDataCallParams } from './utils'
 
 const DEFAULT_TOGGLE_CLASS = '-active'
 
 
 /**
  * Run component's method from HTML
- * Ex: [data-call="modal#register.open"] -> modulus.seek('modal', '#register').open()
- * Ex with params: [data-call="modal#register.open"] [data-call.params="$el"] -> modulus.seek('modal', '#register').open(el)
+ * Ex: [data-call="modal#register.open"]
+ * Ex with params: [data-call="modal#register.open"] [data-call.params='[{ "myAttribute": "myValue" }]']
+ * 
+*  -> modulus.seek('modal', '#register').open({ el, e, data })
  */
 observe('[data-call]', {
   bind(el) {
@@ -17,10 +20,17 @@ observe('[data-call]', {
         const component = seek(name, id)
         if(component) {
           const params = el.dataset['call.params']
+          let data = null
+          
+          if (params) {
+            try {
+              data = JSON.parse(params)?.[0]
+            } catch(e) {
+              console.error('Invalid JSON format in `data-call.params`.', e)
+            }
+          }
 
-          if (params === '$el') component[method](el)
-          else if (params === '$event') component[method](e)
-          else component[method]()
+          component[method]({ el, e, data })
         } else console.error(`Unknown component "${str}"`)
       }
       else console.error(`Invalid call string "${str}"`)

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,6 +73,6 @@ export function parseRefs(el, uid) {
  * @param {String} str 
  * @return {String}
  */
-export function camelize(str) {
+ export function camelize(str) {
   return str.replace(/[\s-]+(\w)/g, (m, c) => c.toUpperCase())
 }


### PR DESCRIPTION
### Feature #9 added.

It comes with a breaking change.  
- `data-call.params` refers to custom parameters and is waiting a JSON format. This parameter is optional.
- Old `$el` and `$event` are deprecated. Those parameters are now automatically passed to the callback method.

Full exemple:
```html
<button data-call="modal#register.open" data-call.params='[{ "myAttr": "myValue" }]'>do something</button>

<div id="register" is="modal">
  Some HTML
</div>
```

```js
modulus.component('modal', class extends Component {
  run() {
    // ...
  }
  /**
   * Open modal and do some stuff
   *
   * @params {HTMLElement} el
   * @params {Event} e
   * @params {Object|null} [data]
   */
  open({ el, e, data }) {
    // el: <button ...>
    // e: Event{ ... }
    // data: { ... } | null
  }
```