### PR TITLE
Feature/config log levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "author": "Aymeric Assier (https://github.com/myeti)",
   "contributors": [
     "Aymeric Assier (https://github.com/myeti)",
-    "Julien Martins Da Costa (https://github.com/jdacosta)"
+    "Julien Martins Da Costa (https://github.com/jdacosta)",
+    "Sébastien Robillard (https://github.com/robiseb)",
+    "Kévin Poccard Soudard (https://github.com/kevpoccs)"
   ],
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -197,11 +197,11 @@ Every event listeners created using `this.on()` are automatically `off()`ed on c
 
 ### Log level
 
-To keep only `warn` and `error` logs (for production usage), set `silent`:
+To keep only `warn` and `error` logs (for production usage), set `production` to `true`:
 ```js
 import modulus from '@wide/modulus'
 
-modulus.config({ silent: true })
+modulus.config({ production: true })
 ```
 
 Or manually assign a log level:
@@ -209,15 +209,37 @@ Or manually assign a log level:
 import modulus, { LOG_LEVELS } from '@wide/modulus'
 
 modulus.config({
-  logLevel: LOG_LEVELS.INFO // DEBUG (default), INFO, WARN, ERROR, NONE
+  log: {
+    level: LOG_LEVELS.INFO // DEBUG (default), INFO, WARN, ERROR, NONE
+  }
 })
 ```
+
+> ⚠️ Note: assign a log level will override the `production` setting.
+
+To disable logs, set `enabled` to `false`:
+```js
+import modulus from '@wide/modulus'
+
+modulus.config({
+  log: {
+    enabled: false
+  }
+})
+```
+
+The default config is setted to show all kind of logs.
 
 
 ## Authors
 
 - **Aymeric Assier** - [github.com/myeti](https://github.com/myeti)
 - **Julien Martins Da Costa** - [github.com/jdacosta](https://github.com/jdacosta)
+
+### Contributors
+
+- **Sébastien Robillard** - [github.com/robiseb](https://github.com/robiseb)
+- **Kévin Poccard Soudard** - [github.com/kevpoccs](https://github.com/kevpoccs)
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,27 @@ modulus.component('foo-bar', class extends Component {
 Every event listeners created using `this.on()` are automatically `off()`ed on component destruction.
 
 
+## Config
+
+### Log level
+
+To keep only `warn` and `error` logs (for production usage), set `silent`:
+```js
+import modulus from '@wide/modulus'
+
+modulus.config({ silent: true })
+```
+
+Or manually assign a log level:
+```js
+import modulus, { LOG_LEVELS } from '@wide/modulus'
+
+modulus.config({
+  logLevel: LOG_LEVELS.INFO // DEBUG (default), INFO, WARN, ERROR, NONE
+})
+```
+
+
 ## Authors
 
 - **Aymeric Assier** - [github.com/myeti](https://github.com/myeti)

--- a/src/directives.js
+++ b/src/directives.js
@@ -1,4 +1,5 @@
 import observe from '@wide/dom-observer'
+import { logger } from './logger'
 import { seek } from './index'
 import { parseDataCallParams } from './utils'
 
@@ -31,9 +32,9 @@ observe('[data-call]', {
           }
 
           component[method]({ el, e, data })
-        } else console.error(`Unknown component "${str}"`)
+        } else logger.error(`Unknown component "${str}"`)
       }
-      else console.error(`Invalid call string "${str}"`)
+      else logger.error(`Invalid call string "${str}"`)
     })
   }
 })

--- a/src/directives.js
+++ b/src/directives.js
@@ -1,7 +1,6 @@
 import observe from '@wide/dom-observer'
 import { logger } from './logger'
 import { seek } from './index'
-import { parseDataCallParams } from './utils'
 
 const DEFAULT_TOGGLE_CLASS = '-active'
 
@@ -27,7 +26,7 @@ observe('[data-call]', {
             try {
               data = JSON.parse(params)?.[0]
             } catch(e) {
-              console.error('Invalid JSON format in `data-call.params`.', e)
+              logger.error('Invalid JSON format in `data-call.params`.', e)
             }
           }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,11 @@ export { LOG_LEVELS } from './logger'
  * @type {Object}
  */
 const DEFAULT_CONFIG = {
-  silent: false,
-  logLevel: LOG_LEVELS.DEBUG
+  production: false,
+  log: {
+    enabled: true,
+    level: null
+  }
 }
 
 
@@ -151,7 +154,17 @@ export function seekAll(name, selector) {
  */
 export function setConfig(values = {}) {
   const config = Object.assign({}, DEFAULT_CONFIG, values)
-  Logger.LEVEL = config.silent ? LOG_LEVELS.WARN : config.logLevel
+  const { enabled, level } = config.log
+
+  if (enabled) {
+    if (level) {
+      Logger.LEVEL = Object.values(LOG_LEVELS).includes(level) ? level : LOG_LEVELS.DEBUG
+    } else {
+      Logger.LEVEL = config.production ? LOG_LEVELS.WARN : LOG_LEVELS.DEBUG
+    }
+  } else {
+    Logger.LEVEL = LOG_LEVELS.NONE
+  }
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,19 @@
 import observe, { seek as _seek } from '@wide/dom-observer'
+import { LOG_LEVELS, Logger, logger } from './logger'
 import { bind, unbind } from './hooks'
 import './directives'
+
+export { LOG_LEVELS } from './logger'
+
+
+/**
+ * Default internal config values
+ * @type {Object}
+ */
+const DEFAULT_CONFIG = {
+  silent: false,
+  logLevel: LOG_LEVELS.DEBUG
+}
 
 
 /**
@@ -39,7 +52,7 @@ export function registerMany(many) {
  * @param {Function} Klass 
  */
 export function registerComponent(name, Klass) {
-  console.debug(`# register component [is=${name}]`)
+  logger(`# register component [is=${name}]`)
   observe(`[is="${name}"]`, {
     bind: el => bind(el, name, Klass),
     unbind: el => unbind(el)
@@ -64,7 +77,7 @@ export function registerComponents(collection) {
  * @param {Function} Klass 
  */
 export function registerWebComponent(name, Klass) {
-  console.debug(`# register web component <${name}>`)
+  logger(`# register web component <${name}>`)
   try {
     window.customElements.define(name, class extends HTMLElement {
       connectedCallback() {
@@ -76,7 +89,7 @@ export function registerWebComponent(name, Klass) {
     })
   }
   catch(err) {
-    console.error(err)
+    logger.error(err)
   }
 }
 
@@ -132,6 +145,17 @@ export function seekAll(name, selector) {
 
 
 /**
+ * Set internal config
+ * - assign log level
+ * @param {Object} values 
+ */
+export function setConfig(values = {}) {
+  const config = Object.assign({}, DEFAULT_CONFIG, values)
+  Logger.LEVEL = config.silent ? LOG_LEVELS.WARN : config.logLevel
+}
+
+
+/**
  * Extend modulus instance
  */
 modulus.register = register
@@ -143,6 +167,7 @@ modulus.webComponents = registerWebComponents
 modulus.imports = registerImports
 modulus.seek = seek
 modulus.seekAll = seekAll
+modulus.config = setConfig
 
 
 /**

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,16 +1,62 @@
 /**
+ * All available log levels
+ * @type {Object<String, Number>}
+ */
+export const LOG_LEVELS = {
+  DEBUG: 0,
+  INFO: 1,
+  WARN: 2,
+  ERROR: 3,
+  NONE: Infinity
+}
+
+
+/**
+ * Map levels to real console functions
+ * @type {Object<String, Function>}
+ */
+const LOG_METHODS = {
+  [LOG_LEVELS.DEBUG]: console.debug,
+  [LOG_LEVELS.INFO]: console.log,
+  [LOG_LEVELS.WARN]: console.warn,
+  [LOG_LEVELS.ERROR]: console.error
+}
+
+
+/**
+ * Write log depending on the level requested
+ * @param {Number} level 
+ * @param {String} prefix 
+ * @param {Array} args 
+ */
+function writeLog(level, prefix, args) {
+  const method = LOG_METHODS[level]
+  if(method && Logger.LEVEL <= level) method(prefix, ...args)
+}
+
+
+/**
  * Logger factory
  * @param {String} prefix 
  */
 export default function Logger(prefix = '') {
-
-  const logger = function(...args) {
-    console.debug(prefix, ...args)
-  }
-
-  logger.info = (...args) => console.log(prefix, ...args)
-  logger.warn = (...args) => console.warn(prefix, ...args)
-  logger.error = (...args) => console.error(prefix, ...args)
-
+  const logger = (...args) => writeLog(LOG_LEVELS.DEBUG, prefix, args)
+  logger.info = (...args) => writeLog(LOG_LEVELS.INFO, prefix, args)
+  logger.warn = (...args) => writeLog(LOG_LEVELS.WARN, prefix, args)
+  logger.error = (...args) => writeLog(LOG_LEVELS.ERROR, prefix, args)
   return logger
 }
+
+
+/**
+ * Logger global level
+ * @type {Number} 
+ */
+Logger.LEVEL = LOG_LEVELS.DEBUG
+
+
+/**
+ * Built-in instance
+ * @type {Logger}
+ */
+export const logger = new Logger()


### PR DESCRIPTION
## Fix issue #8 

- Add a log config option to Modulus

### Log level

To keep only `warn` and `error` logs (for production usage), set `production` to `true`:
```js
import modulus from '@wide/modulus'

modulus.config({ production: true })
```

Or manually assign a log level:
```js
import modulus, { LOG_LEVELS } from '@wide/modulus'

modulus.config({
  log: {
    level: LOG_LEVELS.INFO // DEBUG (default), INFO, WARN, ERROR, NONE
  }
})
```

> ⚠️ Note: assign a log level will override the `production` setting.

To disable logs, set `enabled` to `false`:
```js
import modulus from '@wide/modulus'

modulus.config({
  log: {
    enabled: false
  }
})
```

The default config is setted to show all kind of logs.